### PR TITLE
fix: Correct ReferenceError in image error handler

### DIFF
--- a/src/utils/CachedImage.js
+++ b/src/utils/CachedImage.js
@@ -20,23 +20,29 @@ const findMinIndex = (array, key) => {
 
 // convert image url to base64
 const toDataUrl = (url, width, height, callback, errorCallback, outputFormat) => {
-  var img = new Image(width, height);
+  let canvas = document.createElement("CANVAS");
+  const ctx = canvas.getContext("2d");
+  canvas.width = width;
+  canvas.height = height;
+
+  const img = new Image(width, height);
   img.crossOrigin = "Anonymous";
+
   img.onload = function () {
-    var canvas = document.createElement("CANVAS");
-    canvas.width = width;
-    canvas.height = height;
-    var ctx = canvas.getContext("2d");
-    var dataURL;
     ctx.drawImage(this, 0, 0, width, height);
-    dataURL = canvas.toDataURL(outputFormat);
+    const dataURL = canvas.toDataURL(outputFormat);
     callback(dataURL);
+    // Cleanup
     canvas = null;
   };
-  img.onerror = function (err) {
-    errorCallback(err);
+
+  img.onerror = function (event) {
+    // The event itself is not a detailed error object, so we just trigger the generic error callback.
+    errorCallback(event);
+    // Cleanup
     canvas = null;
   };
+
   img.src = url;
 };
 


### PR DESCRIPTION
This commit fixes a `ReferenceError: canvas is not defined` bug in the `onerror` handler within the `toDataUrl` function in `CachedImage.js`.

The canvas object was being referenced outside of its scope, causing a crash when an image failed to load.

The function has been refactored to correctly manage the canvas element's lifecycle, ensuring it is properly handled in both success and error cases.

This allows the application to correctly catch image loading failures and display the intended error message on the screen.